### PR TITLE
More complete path in layout.

### DIFF
--- a/app/src/main/res/layout/fragment_meals.xml
+++ b/app/src/main/res/layout/fragment_meals.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/grey"
-    tools:context=".MealsFragment">
+    tools:context=".ui.meals.MealsFragment">
 
     <ListView
         android:id="@+id/list_view_meals_list"

--- a/app/src/main/res/layout/fragment_shopping_lists.xml
+++ b/app/src/main/res/layout/fragment_shopping_lists.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/grey"
-    tools:context=".ShoppingListsFragment">
+    tools:context=".ui.activeLists.ShoppingListsFragment">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
The starter code has a couple of paths that may have been written before the Meals and ShoppingLists fragments were organized into separate folders. This seems to have led to "cannot resolve symbol" errors where the tools:context couldn't find the fragments. After adding the folders to the path name, it's possible to hold down command key ( on mac ) and left click and it will now open the proper fragment in Android Studio.
